### PR TITLE
fix paths to infra files

### DIFF
--- a/.ado/workflows/dataDomainDeployment.yml
+++ b/.ado/workflows/dataDomainDeployment.yml
@@ -1,4 +1,4 @@
-name: Data Domain Batch Deployment
+name: Data Domain Deployment
 
 trigger:
   branches:


### PR DESCRIPTION
Some of the paths to the ARM template parameter files were missing the `infra` directory name